### PR TITLE
Check if oom_list is empty

### DIFF
--- a/os/check_out_of_memory/check_out_of_memory.py
+++ b/os/check_out_of_memory/check_out_of_memory.py
@@ -64,7 +64,12 @@ if __name__ == '__main__':
         sys.exit(NAGIOS_EXIT_ERROR)
 
     oom_list = get_oom_entry()
-    matched_oom_list = filter_entry_by_datetime(oom_list, hours_to_check)
+    
+    if not oom_list:
+      matched_oom_list = filter_entry_by_datetime(oom_list, hours_to_check)
+    else:
+      matched_oom_list = []
+
     if len(matched_oom_list) == 0:
         print("OK: No OOM has happened in previous %d hours." % (hours_to_check))
     else:


### PR DESCRIPTION
When I run the script and no oom is in the kernel buffer then I get the following stracktrace.

```
python check_out_of_memory.py --hours_to_check 1
Traceback (most recent call last):
  File "check_out_of_memory.py", line 69, in <module>
    matched_oom_list = filter_entry_by_datetime(oom_list, hours_to_check)
  File "check_out_of_memory.py", line 49, in filter_entry_by_datetime
    entry_seconds = get_time_seconds_from_dmsg(entry)
  File "check_out_of_memory.py", line 30, in get_time_seconds_from_dmsg
    return int(time.mktime(time.strptime(date,'%a %b %d %H:%M:%S %Y')))
  File "/usr/lib/python2.7/_strptime.py", line 478, in _strptime_time
    return _strptime(data_string, format)[0]
  File "/usr/lib/python2.7/_strptime.py", line 332, in _strptime
    (data_string, format))
ValueError: time data '' does not match format '%a %b %d %H:%M:%S %Y'
```

This patch fix that on the python version below.

```
python --version
Python 2.7.12
```